### PR TITLE
Support deleting products via query parameter

### DIFF
--- a/src/main/java/com/example/authserver/AbstractProductHandler.java
+++ b/src/main/java/com/example/authserver/AbstractProductHandler.java
@@ -3,6 +3,9 @@ package com.example.authserver;
 import com.sun.net.httpserver.HttpExchange;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 public abstract class AbstractProductHandler implements RouteHandler {
 
@@ -16,14 +19,66 @@ public abstract class AbstractProductHandler implements RouteHandler {
 
     @Override
     public final void handle(HttpExchange exchange) throws IOException {
-        doHandle(exchange);
+        try {
+            doHandle(exchange);
+        } catch (InvalidProductIdException exception) {
+            responseWriter.writeJson(exchange, 400, Map.of("error", exception.getMessage()));
+        }
     }
 
     protected int extractProductId(HttpExchange exchange) {
+        String query = exchange.getRequestURI().getRawQuery();
+        if (query != null && !query.isBlank()) {
+            for (String param : query.split("&")) {
+                String[] parts = param.split("=", 2);
+                if (parts.length != 2) {
+                    continue;
+                }
+                String name = decode(parts[0]);
+                if (!"id".equalsIgnoreCase(name)) {
+                    continue;
+                }
+                String value = decode(parts[1]).trim();
+                if (value.isEmpty()) {
+                    throw new InvalidProductIdException("Identificador de produto não informado");
+                }
+                return parseId(value);
+            }
+        }
+
         String path = exchange.getRequestURI().getPath();
         int lastSlash = path.lastIndexOf('/');
-        return Integer.parseInt(path.substring(lastSlash + 1));
+        if (lastSlash > 0 && lastSlash < path.length() - 1) {
+            String value = path.substring(lastSlash + 1).trim();
+            if (!value.isEmpty()) {
+                return parseId(value);
+            }
+        }
+
+        throw new InvalidProductIdException("Identificador de produto não informado");
     }
 
     protected abstract void doHandle(HttpExchange exchange) throws IOException;
+
+    private int parseId(String value) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException exception) {
+            throw new InvalidProductIdException("Identificador de produto inválido");
+        }
+    }
+
+    private String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException exception) {
+            throw new InvalidProductIdException("Identificador de produto inválido");
+        }
+    }
+
+    private static class InvalidProductIdException extends RuntimeException {
+        InvalidProductIdException(String message) {
+            super(message);
+        }
+    }
 }

--- a/src/main/java/com/example/authserver/HandlerFactory.java
+++ b/src/main/java/com/example/authserver/HandlerFactory.java
@@ -31,6 +31,7 @@ public class HandlerFactory {
             return switch (method) {
                 case "GET" -> Optional.of(listProductsHandler);
                 case "POST" -> Optional.of(createProductHandler);
+                case "DELETE" -> Optional.of(deleteProductHandler);
                 default -> Optional.of(methodNotAllowedHandler);
             };
         }

--- a/src/test/java/com/example/authserver/ProductHttpHandlerIntegrationTest.java
+++ b/src/test/java/com/example/authserver/ProductHttpHandlerIntegrationTest.java
@@ -93,6 +93,41 @@ class ProductHttpHandlerIntegrationTest {
         assertTrue(getResponse.body().contains("Produto não encontrado"));
     }
 
+    @Test
+    void shouldDeleteProductUsingQueryParameter() throws Exception {
+        Product created = createProduct("Console", "Console portátil", "1999.99");
+
+        HttpResponse<String> deleteResponse = client.send(
+                HttpRequest.newBuilder(uri("/products?id=" + created.getId())).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString()
+        );
+
+        assertEquals(204, deleteResponse.statusCode());
+        assertEquals("", deleteResponse.body());
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDeletingWithoutId() throws Exception {
+        HttpResponse<String> response = client.send(
+                HttpRequest.newBuilder(uri("/products")).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString()
+        );
+
+        assertEquals(400, response.statusCode());
+        assertTrue(response.body().contains("Identificador de produto não informado"));
+    }
+
+    @Test
+    void shouldReturnBadRequestWhenDeletingWithInvalidId() throws Exception {
+        HttpResponse<String> response = client.send(
+                HttpRequest.newBuilder(uri("/products?id=abc")).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString()
+        );
+
+        assertEquals(400, response.statusCode());
+        assertTrue(response.body().contains("Identificador de produto inválido"));
+    }
+
     private Product createProduct(String name, String description, String price) throws Exception {
         String payload = "{" +
                 "\"name\":\"" + name + "\"," +


### PR DESCRIPTION
## Summary
- allow DELETE requests on /products with an id query parameter
- validate product identifiers and return 400 responses for missing or invalid ids
- add integration tests that cover the new deletion flows and error handling

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e3ca4c67408329bc5c5ccb7f9b90b6