### PR TITLE
feat: persist products using JPA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,27 @@
             <version>2.17.1</version>
         </dependency>
         <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.orm</groupId>
+            <artifactId>hibernate-core</artifactId>
+            <version>6.4.4.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>2.0.12</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>5.10.2</version>

--- a/src/main/java/com/example/authserver/AuthServerApplication.java
+++ b/src/main/java/com/example/authserver/AuthServerApplication.java
@@ -2,6 +2,8 @@ package com.example.authserver;
 
 import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpServer;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -12,14 +14,24 @@ public class AuthServerApplication {
 
     public static void main(String[] args) throws IOException {
         int port = 8080;
+        EntityManagerFactory entityManagerFactory = Persistence.createEntityManagerFactory("authServerPU");
+        ProductRepository repository = new ProductRepository(entityManagerFactory);
+        repository.initializeSampleData();
+
         HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
 
-        ProductRepository repository = new ProductRepository();
         HttpContext context = server.createContext("/products", new ProductHttpHandler(repository));
         context.getFilters().add(new RequestLoggingFilter());
 
         ExecutorService executor = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
         server.setExecutor(executor);
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            server.stop(0);
+            executor.shutdown();
+            entityManagerFactory.close();
+        }));
+
         server.start();
         System.out.printf("Servidor iniciado na porta %d%n", port);
     }

--- a/src/main/java/com/example/authserver/CreateProductHandler.java
+++ b/src/main/java/com/example/authserver/CreateProductHandler.java
@@ -21,7 +21,7 @@ public class CreateProductHandler extends AbstractProductHandler {
             responseWriter.writeJson(exchange, 400, Map.of("error", "Dados inválidos"));
             return;
         }
-        Product created = repository.save(new Product(0, payload.getName(), payload.getDescription(), payload.getPrice()));
+        Product created = repository.save(new Product(null, payload.getName(), payload.getDescription(), payload.getPrice()));
         responseWriter.writeJson(exchange, 201, created);
     }
 }

--- a/src/main/java/com/example/authserver/Product.java
+++ b/src/main/java/com/example/authserver/Product.java
@@ -1,29 +1,46 @@
 package com.example.authserver;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
 import java.math.BigDecimal;
 import java.util.Objects;
 
+@Entity
+@Table(name = "products")
 public class Product {
-    private int id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
     private String description;
+
+    @Column(nullable = false)
     private BigDecimal price;
 
     public Product() {
     }
 
-    public Product(int id, String name, String description, BigDecimal price) {
+    public Product(Integer id, String name, String description, BigDecimal price) {
         this.id = id;
         this.name = name;
         this.description = description;
         this.price = price;
     }
 
-    public int getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(int id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 
@@ -56,7 +73,7 @@ public class Product {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Product product = (Product) o;
-        return id == product.id;
+        return Objects.equals(id, product.id);
     }
 
     @Override

--- a/src/main/java/com/example/authserver/ProductRepository.java
+++ b/src/main/java/com/example/authserver/ProductRepository.java
@@ -1,41 +1,115 @@
 package com.example.authserver;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Map;
+import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class ProductRepository {
 
-    private final Map<Integer, Product> products = new ConcurrentHashMap<>();
-    private final AtomicInteger sequence = new AtomicInteger();
+    private final EntityManagerFactory entityManagerFactory;
 
-    public ProductRepository() {
-        save(new Product(0, "Notebook", "Notebook com 16GB RAM", new BigDecimal("5500.00")));
-        save(new Product(0, "Mouse", "Mouse sem fio", new BigDecimal("80.50")));
+    public ProductRepository(EntityManagerFactory entityManagerFactory) {
+        this.entityManagerFactory = entityManagerFactory;
+    }
+
+    public void initializeSampleData() {
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        try {
+            transaction.begin();
+            Long count = entityManager.createQuery("select count(p) from Product p", Long.class)
+                    .getSingleResult();
+            if (count == 0) {
+                entityManager.persist(new Product(null, "Notebook", "Notebook com 16GB RAM", new BigDecimal("5500.00")));
+                entityManager.persist(new Product(null, "Mouse", "Mouse sem fio", new BigDecimal("80.50")));
+            }
+            transaction.commit();
+        } catch (RuntimeException exception) {
+            if (transaction.isActive()) {
+                transaction.rollback();
+            }
+            throw exception;
+        } finally {
+            entityManager.close();
+        }
     }
 
     public Collection<Product> findAll() {
-        return new ArrayList<>(products.values());
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        try {
+            List<Product> result = entityManager.createQuery("select p from Product p order by p.id", Product.class)
+                    .getResultList();
+            result.forEach(entityManager::detach);
+            return result;
+        } finally {
+            entityManager.close();
+        }
     }
 
     public Optional<Product> findById(int id) {
-        return Optional.ofNullable(products.get(id));
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        try {
+            Product product = entityManager.find(Product.class, id);
+            if (product != null) {
+                entityManager.detach(product);
+            }
+            return Optional.ofNullable(product);
+        } finally {
+            entityManager.close();
+        }
     }
 
     public Product save(Product product) {
-        if (product.getId() == 0) {
-            product.setId(sequence.incrementAndGet());
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        try {
+            transaction.begin();
+            Product managed;
+            if (product.getId() == null) {
+                entityManager.persist(product);
+                entityManager.flush();
+                managed = product;
+            } else {
+                managed = entityManager.merge(product);
+            }
+            transaction.commit();
+            entityManager.detach(managed);
+            return managed;
+        } catch (RuntimeException exception) {
+            if (transaction.isActive()) {
+                transaction.rollback();
+            }
+            throw exception;
+        } finally {
+            entityManager.close();
         }
-        products.put(product.getId(), product);
-        return product;
     }
 
     public boolean deleteById(int id) {
-        return products.remove(id) != null;
+        EntityManager entityManager = entityManagerFactory.createEntityManager();
+        EntityTransaction transaction = entityManager.getTransaction();
+        try {
+            transaction.begin();
+            Product product = entityManager.find(Product.class, id);
+            if (product == null) {
+                transaction.commit();
+                return false;
+            }
+            entityManager.remove(product);
+            transaction.commit();
+            return true;
+        } catch (RuntimeException exception) {
+            if (transaction.isActive()) {
+                transaction.rollback();
+            }
+            throw exception;
+        } finally {
+            entityManager.close();
+        }
     }
-
 }

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence" version="3.0">
+    <persistence-unit name="authServerPU" transaction-type="RESOURCE_LOCAL">
+        <class>com.example.authserver.Product</class>
+        <properties>
+            <property name="jakarta.persistence.jdbc.driver" value="org.h2.Driver"/>
+            <property name="jakarta.persistence.jdbc.url" value="jdbc:h2:mem:products;DB_CLOSE_DELAY=-1;MODE=LEGACY"/>
+            <property name="jakarta.persistence.jdbc.user" value="sa"/>
+            <property name="jakarta.persistence.jdbc.password" value=""/>
+            <property name="hibernate.hbm2ddl.auto" value="update"/>
+            <property name="hibernate.show_sql" value="false"/>
+            <property name="hibernate.format_sql" value="false"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/src/test/java/com/example/authserver/ProductRepositoryTest.java
+++ b/src/test/java/com/example/authserver/ProductRepositoryTest.java
@@ -1,47 +1,61 @@
 package com.example.authserver;
 
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.Persistence;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class ProductRepositoryTest {
 
+    private EntityManagerFactory entityManagerFactory;
     private ProductRepository repository;
 
     @BeforeEach
     void setUp() {
-        repository = new ProductRepository();
+        entityManagerFactory = Persistence.createEntityManagerFactory("authServerPU", Map.of(
+                "jakarta.persistence.jdbc.url", "jdbc:h2:mem:product-repository-test-" + UUID.randomUUID() + ";MODE=LEGACY"
+        ));
+        repository = new ProductRepository(entityManagerFactory);
+    }
+
+    @AfterEach
+    void tearDown() {
+        entityManagerFactory.close();
     }
 
     @Test
     void shouldCreateProductsWithIncrementalIds() {
-        Product product = repository.save(new Product(0, "Teclado", "Teclado mecânico", new BigDecimal("350.00")));
-        Product product2 = repository.save(new Product(0, "Headset", "Headset gamer", new BigDecimal("420.00")));
+        Product product = repository.save(new Product(null, "Teclado", "Teclado mecânico", new BigDecimal("350.00")));
+        Product product2 = repository.save(new Product(null, "Headset", "Headset gamer", new BigDecimal("420.00")));
 
         assertEquals(product.getId() + 1, product2.getId());
     }
 
     @Test
     void shouldReturnProductById() {
-        Product product = repository.save(new Product(0, "Cadeira", "Cadeira ergonômica", new BigDecimal("1200.00")));
+        Product product = repository.save(new Product(null, "Cadeira", "Cadeira ergonômica", new BigDecimal("1200.00")));
 
         assertTrue(repository.findById(product.getId()).isPresent());
     }
 
     @Test
     void shouldListAllProducts() {
-        repository.save(new Product(0, "Monitor", "Monitor 4K", new BigDecimal("2500.00")));
-        repository.save(new Product(0, "Webcam", "Webcam HD", new BigDecimal("300.00")));
+        repository.save(new Product(null, "Monitor", "Monitor 4K", new BigDecimal("2500.00")));
+        repository.save(new Product(null, "Webcam", "Webcam HD", new BigDecimal("300.00")));
 
-        assertTrue(repository.findAll().size() >= 2);
+        assertEquals(2, repository.findAll().size());
     }
 
     @Test
     void shouldUpdateExistingProduct() {
-        Product product = repository.save(new Product(0, "Console", "Console de videogame", new BigDecimal("3500.00")));
+        Product product = repository.save(new Product(null, "Console", "Console de videogame", new BigDecimal("3500.00")));
 
         repository.save(new Product(product.getId(), "Console Pro", "Console atualizado", new BigDecimal("4200.00")));
 
@@ -52,7 +66,7 @@ class ProductRepositoryTest {
 
     @Test
     void shouldRemoveProductById() {
-        Product product = repository.save(new Product(0, "Impressora", "Impressora laser", new BigDecimal("1100.00")));
+        Product product = repository.save(new Product(null, "Impressora", "Impressora laser", new BigDecimal("1100.00")));
 
         assertTrue(repository.deleteById(product.getId()));
         assertTrue(repository.findById(product.getId()).isEmpty());


### PR DESCRIPTION
## Summary
- add JPA, Hibernate, H2, and logging dependencies to persist products in a database
- replace the in-memory product repository with an EntityManager-based implementation and bootstrap it from the application entry point
- adjust handlers, configuration, and tests to work with generated identifiers and the new persistence layer

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68e4377daae0832999be8ae0014c5e21